### PR TITLE
Travis pyranha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,24 +25,24 @@ addons:
 
 matrix:
   include:
-    - compiler: gcc
-      env: BUILD_TYPE="Release"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    - compiler: clang
-      env: BUILD_TYPE="Release"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    - compiler: clang
-      env: BUILD_TYPE="Python2"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Release"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    #- compiler: clang
+      #env: BUILD_TYPE="Release"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    #- compiler: clang
+      #env: BUILD_TYPE="Python2"
     - compiler: clang
       env: BUILD_TYPE="Python3"
 
@@ -63,12 +63,18 @@ script:
       elif [[ "${BUILD_TYPE}" == "Release" ]]; then
           cmake -DCMAKE_BUILD_TYPE=Release ../;
       elif [[ "${BUILD_TYPE}" == "Python2" ]]; then
-          pip install --user mpmath;
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local ../;
           make install;
+          # Install mpmath.
+          pip install --user mpmath;
       elif [[ "${BUILD_TYPE}" == "Python3" ]]; then
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local -DBoost_PYTHON_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DBoost_PYTHON_LIBRARY_DEBUG=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.2 -DPYTHON_LIBRARY=/usr/lib/libpython3.2mu.so ../;
           make install;
+          # Install mpmath.
+          wget "http://mpmath.org/files/mpmath-0.19.tar.gz";
+          tar xzf mpmath-0.19.tar.gz;
+          cd cd mpmath-0.19;
+          python3 setup.py install --user;
       fi
     - make
     - if [[ "${BUILD_TYPE}" == "Debug" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,24 +25,24 @@ addons:
 
 matrix:
   include:
-    #- compiler: gcc
-      #env: BUILD_TYPE="Release"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    #- compiler: clang
-      #env: BUILD_TYPE="Release"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    #- compiler: clang
-      #env: BUILD_TYPE="Python2"
+    - compiler: gcc
+      env: BUILD_TYPE="Release"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    - compiler: clang
+      env: BUILD_TYPE="Release"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    - compiler: clang
+      env: BUILD_TYPE="Python2"
     - compiler: clang
       env: BUILD_TYPE="Python3"
 
@@ -60,28 +60,25 @@ script:
     - cd build
     - if [[ "${BUILD_TYPE}" == "Debug" ]]; then
           cmake -DCMAKE_BUILD_TYPE=Debug -DPIRANHA_TEST_SPLIT=yes -DPIRANHA_TEST_SPLIT_NUM=${SPLIT_TEST_NUM} ../;
+          make;
+          ctest -E "thread" -V;
       elif [[ "${BUILD_TYPE}" == "Release" ]]; then
           cmake -DCMAKE_BUILD_TYPE=Release ../;
+          make;
+          ctest -E "gastineau|perminov" -V;
       elif [[ "${BUILD_TYPE}" == "Python2" ]]; then
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local ../;
           make install;
           pip install --user mpmath;
+          python -c "import pyranha.test; pyranha.test.run_test_suite()";
       elif [[ "${BUILD_TYPE}" == "Python3" ]]; then
-          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local -DBoost_PYTHON_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DBoost_PYTHON_LIBRARY_DEBUG=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.2 -DPYTHON_LIBRARY=/usr/lib/libpython3.2mu.so ../;
+          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local -DBoost_PYTHON_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so -DBoost_PYTHON_LIBRARY_DEBUG=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.2 -DPYTHON_LIBRARY=/usr/lib/libpython3.2mu.so ../;
           make install;
           wget "http://mpmath.org/files/mpmath-0.19.tar.gz";
           tar xzf mpmath-0.19.tar.gz;
           cd mpmath-0.19;
           python3 setup.py install --user;
-      fi
-    - make
-    - if [[ "${BUILD_TYPE}" == "Debug" ]]; then
-          ctest -E "thread" -V;
-      elif [[ "${BUILD_TYPE}" == "Release" ]]; then
-          ctest -E "gastineau|perminov" -V;
-      elif [[ "${BUILD_TYPE}" == "Python2" ]]; then
-          python -c "import pyranha.test; pyranha.test.run_test_suite()";
-      elif [[ "${BUILD_TYPE}" == "Python3" ]]; then
+          cd ..;
           python3 -c "import pyranha.test; pyranha.test.run_test_suite()";
       fi
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,24 +25,24 @@ addons:
 
 matrix:
   include:
-    #- compiler: gcc
-      #env: BUILD_TYPE="Release"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    #- compiler: clang
-      #env: BUILD_TYPE="Release"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    #- compiler: clang
-      #env: BUILD_TYPE="Python2"
+    - compiler: gcc
+      env: BUILD_TYPE="Release"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    - compiler: clang
+      env: BUILD_TYPE="Release"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    - compiler: clang
+      env: BUILD_TYPE="Python2"
     - compiler: clang
       env: BUILD_TYPE="Python3"
 
@@ -67,9 +67,6 @@ script:
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local ../;
           make install;
       elif [[ "${BUILD_TYPE}" == "Python3" ]]; then
-          wget "https://bootstrap.pypa.io/get-pip.py";
-          python3 get-pip.py --user;
-          /home/travis/.local/bin/pip install mpmath --user;
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local -DBoost_PYTHON_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DBoost_PYTHON_LIBRARY_DEBUG=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.2 -DPYTHON_LIBRARY=/usr/lib/libpython3.2mu.so ../;
           make install;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
     - libboost-timer1.55-dev
     - libboost-python1.55-dev
     - python-numpy
-    - python-mpmath
+    - python-pip
     - g++-4.8
     - clang-3.8
 
@@ -58,6 +58,7 @@ script:
       elif [[ "${BUILD_TYPE}" == "Release" ]]; then
           cmake -DCMAKE_BUILD_TYPE=Release ../;
       elif [[ "${BUILD_TYPE}" == "Python" ]]; then
+          pip install --user mpmath;
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local ../;
           make install;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,24 +25,24 @@ addons:
 
 matrix:
   include:
-    #- compiler: gcc
-      #env: BUILD_TYPE="Release"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    #- compiler: clang
-      #env: BUILD_TYPE="Release"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    #- compiler: clang
-      #env: BUILD_TYPE="Python2"
+    - compiler: gcc
+      env: BUILD_TYPE="Release"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    - compiler: clang
+      env: BUILD_TYPE="Release"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    - compiler: clang
+      env: BUILD_TYPE="Python2"
     - compiler: clang
       env: BUILD_TYPE="Python3"
 
@@ -73,7 +73,7 @@ script:
           # Install mpmath.
           wget "http://mpmath.org/files/mpmath-0.19.tar.gz";
           tar xzf mpmath-0.19.tar.gz;
-          cd cd mpmath-0.19;
+          cd mpmath-0.19;
           python3 setup.py install --user;
       fi
     - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
     - libboost-timer1.55-dev
     - libboost-python1.55-dev
     - python-numpy
+    - python-mpmath
     - g++-4.8
     - clang-3.8
 
@@ -37,8 +38,8 @@ matrix:
       #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
     #- compiler: clang
       #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    #- compiler: clang
-      #env: BUILD_TYPE="Python"
+    - compiler: clang
+      env: BUILD_TYPE="Python"
 
 install:
     - if [[ "${CC}" == "gcc" ]]; then
@@ -66,7 +67,7 @@ script:
       elif [[ "${BUILD_TYPE}" == "Release" ]]; then
           ctest -E "gastineau|perminov" -V;
       elif [[ "${BUILD_TYPE}" == "Python" ]]; then
-          python -c "import pyranha.test; pyranha.test.run_test_suite()";
+          python -c "import pyranha.test; if pyranha.test.run_test_suite() == 1: raise RuntimeError('One or more tests failed.')";
       fi
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
       elif [[ "${BUILD_TYPE}" == "Release" ]]; then
           ctest -E "gastineau|perminov" -V;
       elif [[ "${BUILD_TYPE}" == "Python" ]]; then
-          python -c "import pyranha.test; if pyranha.test.run_test_suite() == 1: raise RuntimeError('One or more tests failed.')";
+          python -c "import pyranha.test; if pyranha.test.run_test_suite() == 1\: raise RuntimeError('One or more tests failed.')";
       fi
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
     - libboost-chrono1.55-dev
     - libboost-timer1.55-dev
     - libboost-python1.55-dev
+    - python-numpy
     - g++-4.8
     - clang-3.8
 
@@ -36,8 +37,8 @@ matrix:
       #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
     #- compiler: clang
       #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    - compiler: clang
-      env: BUILD_TYPE="Python"
+    #- compiler: clang
+      #env: BUILD_TYPE="Python"
 
 install:
     - if [[ "${CC}" == "gcc" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,12 +65,10 @@ script:
       elif [[ "${BUILD_TYPE}" == "Python2" ]]; then
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local ../;
           make install;
-          # Install mpmath.
           pip install --user mpmath;
       elif [[ "${BUILD_TYPE}" == "Python3" ]]; then
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local -DBoost_PYTHON_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DBoost_PYTHON_LIBRARY_DEBUG=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.2 -DPYTHON_LIBRARY=/usr/lib/libpython3.2mu.so ../;
           make install;
-          # Install mpmath.
           wget "http://mpmath.org/files/mpmath-0.19.tar.gz";
           tar xzf mpmath-0.19.tar.gz;
           cd mpmath-0.19;

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
       elif [[ "${BUILD_TYPE}" == "Release" ]]; then
           ctest -E "gastineau|perminov" -V;
       elif [[ "${BUILD_TYPE}" == "Python" ]]; then
-          python -c "import pyranha; pyranha.test.run_test_suite()";
+          python -c "import pyranha.test; pyranha.test.run_test_suite()";
       fi
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,27 +14,30 @@ addons:
     - libboost-system1.55-dev
     - libboost-chrono1.55-dev
     - libboost-timer1.55-dev
+    - libboost-python1.55-dev
     - g++-4.8
     - clang-3.8
 
 matrix:
   include:
-    - compiler: gcc
-      env: BUILD_TYPE="Release"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Release"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    #- compiler: clang
+      #env: BUILD_TYPE="Release"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
     - compiler: clang
-      env: BUILD_TYPE="Release"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+      env: BUILD_TYPE="Python"
 
 install:
     - if [[ "${CC}" == "gcc" ]]; then
@@ -50,8 +53,10 @@ script:
     - cd build
     - if [[ "${BUILD_TYPE}" == "Debug" ]]; then
           cmake -DCMAKE_BUILD_TYPE=Debug -DPIRANHA_TEST_SPLIT=yes -DPIRANHA_TEST_SPLIT_NUM=${SPLIT_TEST_NUM} ../;
+      elif [[ "${BUILD_TYPE}" == "Python" ]]; then
+          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os ../;
       else
-          cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ../;
+          cmake -DCMAKE_BUILD_TYPE=Release ../;
       fi
     - make
     - if [[ "${BUILD_TYPE}" == "Release" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local ../;
           make install;
       elif [[ "${BUILD_TYPE}" == "Python3" ]]; then
-          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local -DBoost_PYTHON_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libboost_python3.so -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.2 -DPYTHON_LIBRARY=/usr/lib/libpython3.2mu.so ../;
+          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local -DBoost_PYTHON_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libboost_python3.so -DBoost_PYTHON_LIBRARY_DEBUG=/usr/lib/x86_64-linux-gnu/libboost_python3.so -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.2 -DPYTHON_LIBRARY=/usr/lib/libpython3.2mu.so -DPYTHON_LIBRARY_DEBUG=/usr/lib/libpython3.2mu.so ../;
           make install;
       fi
     - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
     - libboost-timer1.55-dev
     # This includes both Boost.Python 2 and 3.
     - libboost-python1.55-dev
+    - python3-numpy
     - g++-4.8
     - clang-3.8
 
@@ -46,11 +47,6 @@ matrix:
           #- python-pip
     - compiler: clang
       env: BUILD_TYPE="Python3"
-      addons:
-        apt:
-          packages:
-          - python3-numpy
-          #- python-pip
 
 install:
     - if [[ "${CC}" == "gcc" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,16 +53,19 @@ script:
     - cd build
     - if [[ "${BUILD_TYPE}" == "Debug" ]]; then
           cmake -DCMAKE_BUILD_TYPE=Debug -DPIRANHA_TEST_SPLIT=yes -DPIRANHA_TEST_SPLIT_NUM=${SPLIT_TEST_NUM} ../;
-      elif [[ "${BUILD_TYPE}" == "Python" ]]; then
-          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os ../;
-      else
+      elif [[ "${BUILD_TYPE}" == "Release" ]]; then
           cmake -DCMAKE_BUILD_TYPE=Release ../;
+      elif [[ "${BUILD_TYPE}" == "Python" ]]; then
+          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local ../;
+          make install
       fi
     - make
-    - if [[ "${BUILD_TYPE}" == "Release" ]]; then
-          ctest -E "gastineau|perminov" -V;
-      elif [[ "${BUILD_TYPE}" == "Debug" ]]; then
+    - if [[ "${BUILD_TYPE}" == "Debug" ]]; then
           ctest -E "thread" -V;
+      elif [[ "${BUILD_TYPE}" == "Release" ]]; then
+          ctest -E "gastineau|perminov" -V;
+      elif [[ "${BUILD_TYPE}" == "Python" ]]; then
+          python -c "import pyranha; pyranha.test.run_test_suite()"
       fi
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,10 @@ addons:
     - libboost-timer1.55-dev
     # This includes both Boost.Python 2 and 3.
     - libboost-python1.55-dev
+    - python3-dev
+    - python-numpy
     - python3-numpy
+    - python-pip
     - g++-4.8
     - clang-3.8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,22 +22,22 @@ addons:
 
 matrix:
   include:
-    #- compiler: gcc
-      #env: BUILD_TYPE="Release"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    #- compiler: clang
-      #env: BUILD_TYPE="Release"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    - compiler: gcc
+      env: BUILD_TYPE="Release"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    - compiler: clang
+      env: BUILD_TYPE="Release"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
     - compiler: clang
       env: BUILD_TYPE="Python"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
       elif [[ "${BUILD_TYPE}" == "Release" ]]; then
           ctest -E "gastineau|perminov" -V;
       elif [[ "${BUILD_TYPE}" == "Python" ]]; then
-          python -c "import pyranha.test; if pyranha.test.run_test_suite() == 1\: raise RuntimeError('One or more tests failed.')";
+          python -c "import pyranha.test; pyranha.test.run_test_suite()";
       fi
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,9 +67,9 @@ script:
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local ../;
           make install;
       elif [[ "${BUILD_TYPE}" == "Python3" ]]; then
-          wget "https://bootstrap.pypa.io/get-pip.py"
-          python3 get-pip.py --user
-          /home/travis/.local/bin/pip install mpmath --user
+          wget "https://bootstrap.pypa.io/get-pip.py";
+          python3 get-pip.py --user;
+          /home/travis/.local/bin/pip install mpmath --user;
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local -DBoost_PYTHON_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DBoost_PYTHON_LIBRARY_DEBUG=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.2 -DPYTHON_LIBRARY=/usr/lib/libpython3.2mu.so ../;
           make install;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,24 +25,24 @@ addons:
 
 matrix:
   include:
-    - compiler: gcc
-      env: BUILD_TYPE="Release"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    - compiler: clang
-      env: BUILD_TYPE="Release"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    - compiler: clang
-      env: BUILD_TYPE="Python2"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Release"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    #- compiler: clang
+      #env: BUILD_TYPE="Release"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    #- compiler: clang
+      #env: BUILD_TYPE="Python2"
     - compiler: clang
       env: BUILD_TYPE="Python3"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ script:
           cmake -DCMAKE_BUILD_TYPE=Release ../;
       elif [[ "${BUILD_TYPE}" == "Python" ]]; then
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local ../;
-          make install
+          make install;
       fi
     - make
     - if [[ "${BUILD_TYPE}" == "Debug" ]]; then
@@ -65,7 +65,7 @@ script:
       elif [[ "${BUILD_TYPE}" == "Release" ]]; then
           ctest -E "gastineau|perminov" -V;
       elif [[ "${BUILD_TYPE}" == "Python" ]]; then
-          python -c "import pyranha; pyranha.test.run_test_suite()"
+          python -c "import pyranha; pyranha.test.run_test_suite()";
       fi
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,32 +14,43 @@ addons:
     - libboost-system1.55-dev
     - libboost-chrono1.55-dev
     - libboost-timer1.55-dev
+    # This includes both Boost.Python 2 and 3.
     - libboost-python1.55-dev
-    - python-numpy
-    - python-pip
     - g++-4.8
     - clang-3.8
 
 matrix:
   include:
-    - compiler: gcc
-      env: BUILD_TYPE="Release"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Release"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    #- compiler: clang
+      #env: BUILD_TYPE="Release"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    #- compiler: clang
+      #env: BUILD_TYPE="Python2"
+      #addons:
+        #apt:
+          #packages:
+          #- python-numpy
+          #- python-pip
     - compiler: clang
-      env: BUILD_TYPE="Release"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    - compiler: clang
-      env: BUILD_TYPE="Python"
+      env: BUILD_TYPE="Python3"
+      addons:
+        apt:
+          packages:
+          - python3-numpy
+          #- python-pip
 
 install:
     - if [[ "${CC}" == "gcc" ]]; then
@@ -57,9 +68,12 @@ script:
           cmake -DCMAKE_BUILD_TYPE=Debug -DPIRANHA_TEST_SPLIT=yes -DPIRANHA_TEST_SPLIT_NUM=${SPLIT_TEST_NUM} ../;
       elif [[ "${BUILD_TYPE}" == "Release" ]]; then
           cmake -DCMAKE_BUILD_TYPE=Release ../;
-      elif [[ "${BUILD_TYPE}" == "Python" ]]; then
+      elif [[ "${BUILD_TYPE}" == "Python2" ]]; then
           pip install --user mpmath;
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local ../;
+          make install;
+      elif [[ "${BUILD_TYPE}" == "Python3" ]]; then
+          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local -DBoost_PYTHON_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libboost_python3.so -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.2 -DPYTHON_LIBRARY=/usr/lib/libpython3.2mu.so ../;
           make install;
       fi
     - make
@@ -67,8 +81,10 @@ script:
           ctest -E "thread" -V;
       elif [[ "${BUILD_TYPE}" == "Release" ]]; then
           ctest -E "gastineau|perminov" -V;
-      elif [[ "${BUILD_TYPE}" == "Python" ]]; then
+      elif [[ "${BUILD_TYPE}" == "Python2" ]]; then
           python -c "import pyranha.test; pyranha.test.run_test_suite()";
+      elif [[ "${BUILD_TYPE}" == "Python3" ]]; then
+          python3 -c "import pyranha.test; pyranha.test.run_test_suite()";
       fi
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local ../;
           make install;
       elif [[ "${BUILD_TYPE}" == "Python3" ]]; then
-          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local -DBoost_PYTHON_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libboost_python3.so -DBoost_PYTHON_LIBRARY_DEBUG=/usr/lib/x86_64-linux-gnu/libboost_python3.so -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.2 -DPYTHON_LIBRARY=/usr/lib/libpython3.2mu.so -DPYTHON_LIBRARY_DEBUG=/usr/lib/libpython3.2mu.so ../;
+          cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local -DBoost_PYTHON_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DBoost_PYTHON_LIBRARY_DEBUG=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.2 -DPYTHON_LIBRARY=/usr/lib/libpython3.2mu.so ../;
           make install;
       fi
     - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,6 @@ matrix:
       #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
     #- compiler: clang
       #env: BUILD_TYPE="Python2"
-      #addons:
-        #apt:
-          #packages:
-          #- python-numpy
-          #- python-pip
     - compiler: clang
       env: BUILD_TYPE="Python3"
 
@@ -72,6 +67,9 @@ script:
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local ../;
           make install;
       elif [[ "${BUILD_TYPE}" == "Python3" ]]; then
+          wget "https://bootstrap.pypa.io/get-pip.py"
+          python3 get-pip.py --user
+          /home/travis/.local/bin/pip install mpmath --user
           cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_PYRANHA=yes -DBUILD_TESTS=no -DCMAKE_CXX_FLAGS_DEBUG=-g0 -DCMAKE_CXX_FLAGS=-Os -DCMAKE_INSTALL_PREFIX=/home/travis/.local -DBoost_PYTHON_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DBoost_PYTHON_LIBRARY_DEBUG=/usr/lib/x86_64-linux-gnu/libboost_python-py32.so.1.55.0 -DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.2 -DPYTHON_LIBRARY=/usr/lib/libpython3.2mu.so ../;
           make install;
       fi

--- a/cmake_modules/PiranhaCompilerLinkerSettings.cmake
+++ b/cmake_modules/PiranhaCompilerLinkerSettings.cmake
@@ -148,6 +148,7 @@ if(CMAKE_COMPILER_IS_CLANGXX OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_IN
 	PIRANHA_CHECK_ENABLE_DEBUG_CXX_FLAG(-Wdisabled-optimization)
 	PIRANHA_CHECK_ENABLE_CXX_FLAG(-fvisibility-inlines-hidden)
 	PIRANHA_CHECK_ENABLE_CXX_FLAG(-fvisibility=hidden)
+	PIRANHA_CHECK_ENABLE_CXX_FLAG(-Werror)
 	# This is useful when the compiler decides the template backtrace is too verbose.
 	PIRANHA_CHECK_ENABLE_DEBUG_CXX_FLAG(-ftemplate-backtrace-limit=0)
 	PIRANHA_CHECK_ENABLE_DEBUG_CXX_FLAG(-fstack-protector-all)

--- a/cmake_modules/PiranhaCompilerLinkerSettings.cmake
+++ b/cmake_modules/PiranhaCompilerLinkerSettings.cmake
@@ -148,7 +148,6 @@ if(CMAKE_COMPILER_IS_CLANGXX OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_IN
 	PIRANHA_CHECK_ENABLE_DEBUG_CXX_FLAG(-Wdisabled-optimization)
 	PIRANHA_CHECK_ENABLE_CXX_FLAG(-fvisibility-inlines-hidden)
 	PIRANHA_CHECK_ENABLE_CXX_FLAG(-fvisibility=hidden)
-	PIRANHA_CHECK_ENABLE_CXX_FLAG(-Werror)
 	# This is useful when the compiler decides the template backtrace is too verbose.
 	PIRANHA_CHECK_ENABLE_DEBUG_CXX_FLAG(-ftemplate-backtrace-limit=0)
 	PIRANHA_CHECK_ENABLE_DEBUG_CXX_FLAG(-fstack-protector-all)

--- a/pyranha/core.cpp
+++ b/pyranha/core.cpp
@@ -115,16 +115,11 @@ BOOST_PYTHON_MODULE(_core)
 		::PyErr_SetString(PyExc_RuntimeError,"error while creating the 'types' submodule");
 		bp::throw_error_already_set();
 	}
-	// NOTE: apparently there is a difference in behaviour here: Python2 returns a borrowed reference from PyImport_AddModule,
-	// Python3 a new one. Check:
-	// https://docs.python.org/3/c-api/import.html
-	// versus
-	// https://docs.python.org/2/c-api/import.html
-#if PY_MAJOR_VERSION < 3
+	// NOTE: I think at one point in the past there was a typo in the Python3 C API documentation
+	// which hinted at a difference in behaviour for PyImport_AddModule between 2 and 3 (new reference
+	// vs borrowed reference). Current documentation states that the reference is always
+	// borrowed, both in Python 2 and 3.
 	auto types_module = bp::object(bp::handle<>(bp::borrowed(types_module_ptr)));
-#else
-	auto types_module = bp::object(bp::handle<>(types_module_ptr));
-#endif
 	bp::scope().attr("types") = types_module;
 	// Expose concrete instances of the type generator.
 	pyranha::expose_type_generator<signed char>("signed_char");

--- a/pyranha/test.py
+++ b/pyranha/test.py
@@ -773,7 +773,10 @@ class tutorial_test_case(_ut.TestCase):
 def run_test_suite():
 	"""Run the full test suite.
 	
+	This function will return 0 if all tests pass, 1 otherwise.
+	
 	"""
+	retval = 0
 	suite = _ut.TestLoader().loadTestsFromTestCase(basic_test_case)
 	suite.addTest(mpmath_test_case())
 	suite.addTest(math_test_case())
@@ -786,7 +789,9 @@ def run_test_suite():
 	suite.addTest(t_integrate_test_case())
 	suite.addTest(truncate_degree_test_case())
 	suite.addTest(doctests_test_case())
-	_ut.TextTestRunner(verbosity=2).run(suite)
+	test_result = _ut.TextTestRunner(verbosity=2).run(suite)
+	if len(test_result.failures) > 0:
+		retval = 1
 	suite = _ut.TestLoader().loadTestsFromTestCase(tutorial_test_case)
 	# Context for the suppression of output while running the tutorials. Inspired by:
 	# http://stackoverflow.com/questions/8522689/how-to-temporary-hide-stdout-or-stderr-while-running-a-unittest-in-python
@@ -806,4 +811,7 @@ def run_test_suite():
 			import sys
 			sys.stdout = self._stdout
 	with suppress_stdout():
-		_ut.TextTestRunner(verbosity=2).run(suite)
+		test_result = _ut.TextTestRunner(verbosity=2).run(suite)
+		if len(test_result.failures) > 0:
+			retval = 1
+	return retval

--- a/pyranha/test.py
+++ b/pyranha/test.py
@@ -773,7 +773,7 @@ class tutorial_test_case(_ut.TestCase):
 def run_test_suite():
 	"""Run the full test suite.
 	
-	This function will return 0 if all tests pass, 1 otherwise.
+	This function will raise an exception if at least one test fails.
 	
 	"""
 	retval = 0
@@ -814,4 +814,5 @@ def run_test_suite():
 		test_result = _ut.TextTestRunner(verbosity=2).run(suite)
 		if len(test_result.failures) > 0:
 			retval = 1
-	return retval
+	if retval != 0:
+		raise RuntimeError('One or more tests failed.')

--- a/src/piranha.hpp
+++ b/src/piranha.hpp
@@ -163,7 +163,7 @@ see https://www.gnu.org/licenses/. */
  * \todo related to the above: we should probably generalise the integral_combination() in polynomial to deal also with recursively-represented polys,
  * so that, e.g., we can use them as coefficients in poisson series. Also the polynomial's special pow() and integrate() method should be able to deal
  * with recursive polys in the same fashion. This should probably be a bullet point if we ever decide to support recrusive polynomials as first-class citizens.
- * \todo disable test building by default.
+ * \todo disable test building by default. Remember to update CI for this.
  * \todo the tuning:: class should probably be rolled into settings.
  * \todo think about removing the noexcept requirements for ignorability and compatibility of terms. This makes sense logically as ignorability is anyway
  * gonna call is_zero(), which might throw (see bp_object for instance), we might end up simplifying the logic and we don't lose much (not a big deal


### PR DESCRIPTION
This PR enables a pyranha build + test on travis. In order for this to work, the compiler flags ``-Os -g0`` need to be used in order to curb memory usage, and the clang compiler is used for the same reason.

The build uses the default Python version on the VM, which is 2.7 at the moment. It would be good in the future to have another build which tests against Python 3.

@isuruf thoughts?