### PR TITLE
Add a macro to enable conditionally C++14 if supported by the compiler.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
     - python3-numpy
     - python-pip
     - g++-4.8
-    - clang
+    - clang-3.8
     - doxygen
     - graphviz
     - graphviz-dev
@@ -40,34 +40,34 @@ matrix:
   include:
     - compiler: gcc
       env: BUILD_TYPE="Release"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    - compiler: gcc
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    - compiler: gcc
-      env: BUILD_TYPE="Coverage" SPLIT_TEST_NUM="0"
-    - compiler: gcc
-      env: BUILD_TYPE="Coverage" SPLIT_TEST_NUM="1"
-    - compiler: gcc
-      env: BUILD_TYPE="Coverage" SPLIT_TEST_NUM="2"
-    - compiler: clang
-      env: BUILD_TYPE="Release"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    - compiler: clang
-      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    - compiler: clang
-      env: BUILD_TYPE="Python2"
-    - compiler: clang
-      env: BUILD_TYPE="Python3"
-    - compiler: clang
-      env: BUILD_TYPE="Tutorial"
-    - compiler: gcc
-      env: BUILD_TYPE="Doxygen"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Coverage" SPLIT_TEST_NUM="0"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Coverage" SPLIT_TEST_NUM="1"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Coverage" SPLIT_TEST_NUM="2"
+    #- compiler: clang
+      #env: BUILD_TYPE="Release"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    #- compiler: clang
+      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    #- compiler: clang
+      #env: BUILD_TYPE="Python2"
+    #- compiler: clang
+      #env: BUILD_TYPE="Python3"
+    #- compiler: clang
+      #env: BUILD_TYPE="Tutorial"
+    #- compiler: gcc
+      #env: BUILD_TYPE="Doxygen"
 
 install:
     - if [[ "${CC}" == "clang" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,34 +40,34 @@ matrix:
   include:
     - compiler: gcc
       env: BUILD_TYPE="Release"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Coverage" SPLIT_TEST_NUM="0"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Coverage" SPLIT_TEST_NUM="1"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Coverage" SPLIT_TEST_NUM="2"
-    #- compiler: clang
-      #env: BUILD_TYPE="Release"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
-    #- compiler: clang
-      #env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
-    #- compiler: clang
-      #env: BUILD_TYPE="Python2"
-    #- compiler: clang
-      #env: BUILD_TYPE="Python3"
-    #- compiler: clang
-      #env: BUILD_TYPE="Tutorial"
-    #- compiler: gcc
-      #env: BUILD_TYPE="Doxygen"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    - compiler: gcc
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    - compiler: gcc
+      env: BUILD_TYPE="Coverage" SPLIT_TEST_NUM="0"
+    - compiler: gcc
+      env: BUILD_TYPE="Coverage" SPLIT_TEST_NUM="1"
+    - compiler: gcc
+      env: BUILD_TYPE="Coverage" SPLIT_TEST_NUM="2"
+    - compiler: clang
+      env: BUILD_TYPE="Release"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="0"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="1"
+    - compiler: clang
+      env: BUILD_TYPE="Debug" SPLIT_TEST_NUM="2"
+    - compiler: clang
+      env: BUILD_TYPE="Python2"
+    - compiler: clang
+      env: BUILD_TYPE="Python3"
+    - compiler: clang
+      env: BUILD_TYPE="Tutorial"
+    - compiler: gcc
+      env: BUILD_TYPE="Doxygen"
 
 install:
     - if [[ "${CC}" == "clang" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
     - python3-numpy
     - python-pip
     - g++-4.8
-    - clang-3.8
+    - clang
     - doxygen
     - graphviz
     - graphviz-dev

--- a/cmake_modules/PiranhaCompilerLinkerSettings.cmake
+++ b/cmake_modules/PiranhaCompilerLinkerSettings.cmake
@@ -53,6 +53,22 @@ macro(PIRANHA_CHECK_UINT128_T)
 	ENDIF()
 endmacro(PIRANHA_CHECK_UINT128_T)
 
+# Setup the C++ standard flag. We try C++14 first, if not available we go with C++11.
+macro(PIRANHA_SET_CPP_STD_FLAG)
+	# This is valid for GCC, clang and Intel. I think that MSVC has the std version hardcoded.
+	if(CMAKE_COMPILER_IS_CLANGXX OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_INTELXX)
+		set(PIRANHA_CHECK_CXX_FLAG)
+		check_cxx_compiler_flag("-std=c++14" PIRANHA_CHECK_CXX_FLAG)
+		if(PIRANHA_CHECK_CXX_FLAG)
+			message(STATUS "C++14 supported by the compiler, enabling.")
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+		else()
+			message(STATUS "C++14 is not supported by the compiler, C++11 will be enabled.")
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+		endif()
+	endif()
+endmacro()
+
 # Configuration for GCC.
 IF(CMAKE_COMPILER_IS_GNUCXX)
 	MESSAGE(STATUS "GNU compiler detected, checking version.")
@@ -72,7 +88,7 @@ IF(CMAKE_COMPILER_IS_GNUCXX)
 		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g1")
 	endif()
 	# Set the standard flag.
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+	PIRANHA_SET_CPP_STD_FLAG()
 	# Enable libstdc++ pedantic debug mode in debug builds.
 	# NOTE: this is disabled by default, as it requires the c++ library to be compiled with this
 	# flag enabled in order to be reliable (and this is not the case usually):
@@ -103,7 +119,8 @@ IF(CMAKE_COMPILER_IS_CLANGXX)
 		MESSAGE(FATAL_ERROR "Unsupported Clang version, please upgrade your compiler.")
 	ENDIF(NOT CLANG_VERSION_CHECK)
 	MESSAGE(STATUS "Clang version is ok.")
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+	# Set the standard flag.
+	PIRANHA_SET_CPP_STD_FLAG()
 	# This used to be necessary with earlier versions of Clang which
 	# were not completely compatible with GCC's stdlib. Nowadays it seems
 	# unnecessary on most platforms.
@@ -121,8 +138,10 @@ if(CMAKE_COMPILER_IS_INTELXX)
 		message(FATAL_ERROR "Unsupported Intel compiler version, please upgrade your compiler.")
 	endif()
 	message(STATUS "Intel compiler version is ok.")
+	# Set the standard flag.
+	PIRANHA_SET_CPP_STD_FLAG()
 	# The diagnostic from the Intel compiler can be wrong and a pain in the ass.
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -diag-disable 2304,2305,1682,2259,3373")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -diag-disable 2304,2305,1682,2259,3373")
 	PIRANHA_CHECK_UINT128_T()
 endif()
 

--- a/tests/math.cpp
+++ b/tests/math.cpp
@@ -598,6 +598,7 @@ BOOST_AUTO_TEST_CASE(math_canonical_test)
 // Non-evaluable, missing copy-ctor.
 struct fake_ne
 {
+	fake_ne &operator=(const fake_ne &) = delete;
 	fake_ne(const fake_ne &) = delete;
 };
 

--- a/tests/symbol_set.cpp
+++ b/tests/symbol_set.cpp
@@ -418,6 +418,7 @@ class pmap1_t {};
 class pmap2_t
 {
 	public:
+		pmap2_t &operator=(const pmap2_t &) = delete;
 		pmap2_t(const pmap2_t &) = delete;
 };
 
@@ -436,6 +437,7 @@ class pmap4_t
 class pmap5_t
 {
 	public:
+		pmap5_t &operator=(const pmap5_t &) = delete;
 		~pmap5_t() = delete;
 };
 

--- a/tests/type_traits.cpp
+++ b/tests/type_traits.cpp
@@ -1635,6 +1635,7 @@ PIRANHA_DECL_ITT_SPEC(iter03,fake_it_traits_input<int>)
 // Broken iterator, minimal requirements.
 struct iter04
 {
+	iter04 &operator=(const iter04 &) = delete;
 	~iter04() = delete;
 	int &operator*();
 	iter04 &operator++();


### PR DESCRIPTION
Note that this does **not** mean that a C++14 compiler is now needed: the ``-std=c++14`` flag is enabled only if the compiler supports it, and Piranha will not use any C++14 construct for a while at least. IOW, this is just preparatory work.