### PR TITLE
Tentative fix for pyranha test problem.

### DIFF
--- a/pyranha/math.py
+++ b/pyranha/math.py
@@ -889,10 +889,9 @@ def lambdify(t,x,names,extra_map = {}):
 	the expression :math:`x+y+z` as follows:
 
 	>>> from pyranha.types import polynomial, rational, k_monomial
-	>>> from math import sqrt
 	>>> pt = polynomial(rational,k_monomial)()
 	>>> x,y,z = x,y,z = pt('x'),pt('y'),pt('z')
-	>>> l = lambdify(float,x+y+z,['x','y'],{'z': lambda a: sqrt(3.*a[0] + a[1])})
+	>>> l = lambdify(float,x+y+z,['x','y'],{'z': lambda a: (3.*a[0] + a[1])**.5})
 	>>> l([1.,2.]) # doctest: +ELLIPSIS
 	5.236067977...
 
@@ -915,7 +914,6 @@ def lambdify(t,x,names,extra_map = {}):
 		callables in *extra_map*
 
 	>>> from pyranha.types import polynomial, rational, k_monomial
-	>>> from math import sqrt
 	>>> pt = polynomial(rational,k_monomial)()
 	>>> x,y,z = x,y,z = pt('x'),pt('y'),pt('z')
 	>>> l = lambdify(int,2*x-y+3*z,['z','y','x'])
@@ -923,7 +921,7 @@ def lambdify(t,x,names,extra_map = {}):
 	Fraction(7, 1)
 	>>> l([1,2,-3])
 	Fraction(-5, 1)
-	>>> l = lambdify(float,x+y+z,['x','y'],{'z': lambda a: sqrt(3.*a[0] + a[1])})
+	>>> l = lambdify(float,x+y+z,['x','y'],{'z': lambda a: (3.*a[0] + a[1])**.5})
 	>>> l([1.,2.]) # doctest: +ELLIPSIS
 	5.236067977...
 	>>> l([1]) # doctest: +IGNORE_EXCEPTION_DETAIL

--- a/pyranha/test.py
+++ b/pyranha/test.py
@@ -1009,10 +1009,13 @@ class doctests_test_case(_ut.TestCase):
 		import doctest
 		import pyranha
 		from . import celmec, math, test
-		doctest.testmod(pyranha)
-		doctest.testmod(celmec)
-		doctest.testmod(math)
-		doctest.testmod(test)
+		try:
+			doctest.testmod(pyranha,raise_on_error=True)
+			doctest.testmod(celmec,raise_on_error=True)
+			doctest.testmod(math,raise_on_error=True)
+			doctest.testmod(test,raise_on_error=True)
+		except Exception as e:
+			self.fail(str(e))
 
 class tutorial_test_case(_ut.TestCase):
 	"""Test case that will check the tutorial files.


### PR DESCRIPTION
A test failed in Python 2, and it failed silently because we did not check for doctest failures properly. This should fix both problems.