### PR TITLE
GMP future proofing

### DIFF
--- a/src/piranha.hpp
+++ b/src/piranha.hpp
@@ -205,8 +205,10 @@ see https://www.gnu.org/licenses/. */
  * \todo the evaluate requirements and type trait do not fail when the second type is a reference. this should be fixed
  * in the type-traits rework.
  * \todo in the pyranha doc improvements, we should probably handle bettere unspecified exceptions and document
- * the return type as well for consistency (see lambdify docs).
+ * the return type as well for consistency (see lambdify docs) -> actually start using sphinx napoleon
  * \todo "quick install" should not be the title of the getting started section in sphinx
+ * \todo consider poly::udivrem(5*x**2,2*x). This throws an inexact division error triggered by inexact integral cf
+ * division, but maybe it should just return (0,5*x**2).
  */
 namespace piranha
 {

--- a/tests/mp_integer_01.cpp
+++ b/tests/mp_integer_01.cpp
@@ -99,6 +99,8 @@ using size_types = boost::mpl::vector<std::integral_constant<int,0>,std::integra
 #endif
 	>;
 
+using detail::mpz_alloc_t;
+
 // Constructors and assignments.
 struct constructor_tester
 {
@@ -110,31 +112,31 @@ struct constructor_tester
 		std::cout << "Size of " << T::value << ": " << sizeof(int_type) << '\n';
 		std::cout << "Alignment of " << T::value << ": " << alignof(int_type) << '\n';
 		int_type n;
-		BOOST_CHECK(n._mp_alloc == 0);
+		BOOST_CHECK(n._mp_alloc == mpz_alloc_t(-1));
 		BOOST_CHECK(n._mp_size == 0);
 		BOOST_CHECK(n.m_limbs == limbs_type());
 		n.m_limbs[0u] = 4;
 		n._mp_size = 1;
 		int_type m;
 		m = n;
-		BOOST_CHECK(m._mp_alloc == 0);
+		BOOST_CHECK(m._mp_alloc == mpz_alloc_t(-1));
 		BOOST_CHECK(m._mp_size == 1);
 		BOOST_CHECK(m.m_limbs[1u] == 0);
 		BOOST_CHECK(m.m_limbs[0u] == 4);
 		n.m_limbs[0u] = 5;
 		n._mp_size = -1;
 		m = std::move(n);
-		BOOST_CHECK(m._mp_alloc == 0);
+		BOOST_CHECK(m._mp_alloc == mpz_alloc_t(-1));
 		BOOST_CHECK(m._mp_size == -1);
 		BOOST_CHECK(m.m_limbs[1u] == 0);
 		BOOST_CHECK(m.m_limbs[0u] == 5);
 		int_type o(m);
-		BOOST_CHECK(o._mp_alloc == 0);
+		BOOST_CHECK(o._mp_alloc == mpz_alloc_t(-1));
 		BOOST_CHECK(o._mp_size == -1);
 		BOOST_CHECK(o.m_limbs[1u] == 0);
 		BOOST_CHECK(o.m_limbs[0u] == 5);
 		int_type p(std::move(o));
-		BOOST_CHECK(p._mp_alloc == 0);
+		BOOST_CHECK(p._mp_alloc == mpz_alloc_t(-1));
 		BOOST_CHECK(p._mp_size == -1);
 		BOOST_CHECK(p.m_limbs[1u] == 0);
 		BOOST_CHECK(p.m_limbs[0u] == 5);
@@ -2466,7 +2468,8 @@ struct union_ctor_tester
 		BOOST_CHECK(n.is_static());
 		n.promote();
 		BOOST_CHECK(!n.is_static());
-		BOOST_CHECK(n.g_dy()._mp_alloc > 0);
+		// NOTE: in recent GMP versions this could be zero (lazy init).
+		BOOST_CHECK(n.g_dy()._mp_alloc >= 0);
 		BOOST_CHECK(n.g_dy()._mp_d != nullptr);
 		// Copy ctor tests.
 		int_type n1;

--- a/tests/mp_rational.cpp
+++ b/tests/mp_rational.cpp
@@ -84,8 +84,8 @@ struct mpq_raii
 	mpq_raii()
 	{
 		::mpq_init(&m_mpq);
-		piranha_assert(mpq_numref(&m_mpq)->_mp_alloc > 0);
-		piranha_assert(mpq_denref(&m_mpq)->_mp_alloc > 0);
+		piranha_assert(mpq_numref(&m_mpq)->_mp_alloc >= 0);
+		piranha_assert(mpq_denref(&m_mpq)->_mp_alloc >= 0);
 	}
 	mpq_raii(const mpq_raii &) = delete;
 	mpq_raii(mpq_raii &&) = delete;


### PR DESCRIPTION
Currently in piranha the ``mp_integer`` class uses the ``_mp_alloc`` field of the GMP ``mpz_struct`` in order to discern between an integer stored in static storage (``_mp_alloc == 0``) or dynamic storage (``_mp_alloc>0``). This exploit an implementation detail of GMP: a correctly initialised ``mpz_t`` always allocates at least one limb (and thus has ``_mp_alloc>0``).

It looks like this will change in upcoming GMP versions:

https://gmplib.org/repo/gmp/file/835f8974ff6e/mpz/init.c
https://gmplib.org/list-archives/gmp-devel/2016-April/004271.html

That is, it looks like in future GMP versions a correct ``mpz_t`` might have ``_mp_alloc == 0``.

In order to prepare for this, this branch changes the special value that signals static storage in ``mp_integer`` from 0 to -1.

@isuruf do you have any comment on this? Contrary to my initial assessment, ``_mp_alloc`` is actually a signed integer, so a value of -1 is really -1 (and not the maximum value representable by the type of ``_mp_alloc``). Do you think ``std::numeric_limits<>::max()`` would be a better sentinel value for static storage?