### PR TITLE
Feature: add single thread option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,10 @@ option(PIRANHA_WITH_BZIP2 "Enable support for bzip2 compression." OFF)
 option(PIRANHA_INSTALL_HEADERS "Enable the installation of the headers." ON)
 mark_as_advanced(PIRANHA_INSTALL_HEADERS)
 
+# Configure piranha to only run on the main thread.
+option(PIRANHA_SINGLE_THREAD "Configure piranha to only run on the main thread." OFF)
+mark_as_advanced(PIRANHA_SINGLE_THREAD)
+
 # A general-purpose option to signal that we intend to run Piranha under Valgrind.
 # At the moment it just disables tests involving long double that give problems in Valgrind,
 # in the future it might become a more general-purpose flag.

--- a/src/config.hpp.in
+++ b/src/config.hpp.in
@@ -41,6 +41,7 @@ see https://www.gnu.org/licenses/. */
 @PIRANHA_ENABLE_MSGPACK@
 @PIRANHA_ENABLE_ZLIB@
 @PIRANHA_ENABLE_BZIP2@
+#cmakedefine PIRANHA_SINGLE_THREAD
 // clang-format on
 // End of defines instantiated by CMake.
 

--- a/src/detail/parallel_vector_transform.hpp
+++ b/src/detail/parallel_vector_transform.hpp
@@ -52,9 +52,12 @@ inline void parallel_vector_transform(unsigned n_threads, const std::vector<T> &
     if (unlikely(ic.size() != oc.size())) {
         piranha_throw(std::invalid_argument, "mismatched vector sizes");
     }
+#ifndef PIRANHA_SINGLE_THREAD
     if (n_threads == 1u) {
+#endif
         std::transform(ic.begin(), ic.end(), oc.begin(), op);
         return;
+#ifndef PIRANHA_SINGLE_THREAD
     }
     const auto block_size = ic.size() / n_threads;
     auto local_transform = [&op](T const *b, T const *e, U *o) { std::transform(b, e, o, op); };
@@ -73,7 +76,8 @@ inline void parallel_vector_transform(unsigned n_threads, const std::vector<T> &
     } catch (...) {
         ff_list.wait_all();
         throw;
-    }
+   }
+#endif
 }
 }
 }

--- a/src/detail/parallel_vector_transform.hpp
+++ b/src/detail/parallel_vector_transform.hpp
@@ -76,7 +76,7 @@ inline void parallel_vector_transform(unsigned n_threads, const std::vector<T> &
     } catch (...) {
         ff_list.wait_all();
         throw;
-   }
+    }
 #endif
 }
 }

--- a/src/hash_set.hpp
+++ b/src/hash_set.hpp
@@ -491,12 +491,15 @@ private:
         if (unlikely(!new_ptr)) {
             piranha_throw(std::bad_alloc, );
         }
+#ifndef PIRANHA_SINGLE_THREAD
         if (n_threads == 1u) {
+#endif
             // Default-construct the elements of the array.
             // NOTE: this is a noexcept operation, no need to account for rolling back.
             for (size_type i = 0u; i < size; ++i) {
                 allocator().construct(&new_ptr[i]);
             }
+#ifndef PIRANHA_SINGLE_THREAD
         } else {
             // Sync variables.
             using crs_type = std::vector<std::pair<size_type, size_type>>;
@@ -540,6 +543,7 @@ private:
                 throw;
             }
         }
+#endif
         // Assign the members.
         ptr() = new_ptr;
         m_log2_size = log2_size;
@@ -689,7 +693,8 @@ public:
      * @param n_buckets desired number of buckets.
      * @param h hasher functor.
      * @param k equality predicate.
-     * @param n_threads number of threads to use during initialisation.
+     * @param n_threads number of threads to use during initialisation. Note: if piranha is configured with
+     * PIRANHA_SINGLE_THREAD this argument has no effect.
      *
      * @throws std::bad_alloc if the desired number of buckets is greater than an implementation-defined maximum, or in
      * case
@@ -1133,7 +1138,8 @@ public:
      * the rehash operation.
      *
      * @param new_size new desired number of buckets.
-     * @param n_threads number of threads to use.
+     * @param n_threads number of threads to use. Note: if piranha is configured with
+     * PIRANHA_SINGLE_THREAD this argument has no effect.
      *
      * @throws std::invalid_argument if \p n_threads is zero.
      * @throws unspecified any exception thrown by the constructor from number of buckets,

--- a/src/poisson_series.hpp
+++ b/src/poisson_series.hpp
@@ -853,10 +853,13 @@ class series_multiplier<Series, detail::ps_series_multiplier_enabler<Series>> : 
         // NOTE: if we ever implement multi-threaded series division we most likely need
         // to revisit this.
         piranha_assert(this->m_n_threads > 0u);
+#ifndef PIRANHA_SINGLE_THREAD
         if (this->m_n_threads == 1u) {
+#endif
             // This is possible, as the requirements of series divisibility and trig key
             // multipliability overlap.
             s /= 2;
+#ifndef PIRANHA_SINGLE_THREAD
         } else {
             using bucket_size_type = typename base::bucket_size_type;
             using term_type = typename Series::term_type;
@@ -913,6 +916,7 @@ class series_multiplier<Series, detail::ps_series_multiplier_enabler<Series>> : 
             piranha_assert(tot <= s.size());
             container._update_size(static_cast<bucket_size_type>(s.size() - tot));
         }
+#endif
     }
 
 public:

--- a/src/polynomial.hpp
+++ b/src/polynomial.hpp
@@ -2468,11 +2468,14 @@ class series_multiplier<Series, detail::poly_multiplier_enabler<Series>> : publi
                 std::transform(minmax_values.begin(), minmax_values.end(), (*start)->m_key.begin(),
                                minmax_values.begin(), update_minmax{});
             }
+#ifndef PIRANHA_SINGLE_THREAD
             if (this->m_n_threads == 1u) {
+#endif
                 // In single thread the output mmv should be written only once, after being def-inited.
                 piranha_assert(mmv->empty());
                 // Just move in the local minmax values in single-threaded mode.
                 *mmv = std::move(minmax_values);
+#ifndef PIRANHA_SINGLE_THREAD
             } else {
                 std::lock_guard<std::mutex> lock(mut);
                 if (mmv->empty()) {
@@ -2489,6 +2492,7 @@ class series_multiplier<Series, detail::poly_multiplier_enabler<Series>> : publi
                     std::transform(minmax_values.begin(), minmax_values.end(), mmv->begin(), mmv->begin(), updater);
                 }
             }
+#endif
         };
         // minmax vectors for the two series.
         mm_vec minmax_values1, minmax_values2;
@@ -2552,9 +2556,12 @@ class series_multiplier<Series, detail::poly_multiplier_enabler<Series>> : publi
                 std::transform(minmax_values.begin(), minmax_values.end(), tmp_vec.begin(), minmax_values.begin(),
                                update_minmax{});
             }
+#ifndef PIRANHA_SINGLE_THREAD
             if (this->m_n_threads == 1u) {
+#endif
                 piranha_assert(mmv->empty());
                 *mmv = std::move(minmax_values);
+#ifndef PIRANHA_SINGLE_THREAD
             } else {
                 std::lock_guard<std::mutex> lock(mut);
                 if (mmv->empty()) {
@@ -2569,6 +2576,7 @@ class series_multiplier<Series, detail::poly_multiplier_enabler<Series>> : publi
                     std::transform(minmax_values.begin(), minmax_values.end(), mmv->begin(), mmv->begin(), updater);
                 }
             }
+#endif
         };
         mm_vec minmax_values1, minmax_values2;
         check_bounds_impl(minmax_values1, minmax_values2, thread_func);
@@ -2594,9 +2602,12 @@ class series_multiplier<Series, detail::poly_multiplier_enabler<Series>> : publi
     template <typename MmVec, typename Func>
     void check_bounds_impl(MmVec &minmax_values1, MmVec &minmax_values2, Func &thread_func) const
     {
+#ifndef PIRANHA_SINGLE_THREAD
         if (this->m_n_threads == 1u) {
+#endif
             thread_func(0u, &(this->m_v1), &minmax_values1);
             thread_func(0u, &(this->m_v2), &minmax_values2);
+#ifndef PIRANHA_SINGLE_THREAD
         } else {
             // Series 1.
             {
@@ -2631,6 +2642,7 @@ class series_multiplier<Series, detail::poly_multiplier_enabler<Series>> : publi
                 }
             }
         }
+#endif
     }
     // Enabler for the call operator.
     template <typename T>
@@ -3154,7 +3166,9 @@ private:
                 }
             }
         };
+#ifndef PIRANHA_SINGLE_THREAD
         if (this->m_n_threads == 1u) {
+#endif
             try {
                 // Single threaded case.
                 // Create the vector of tasks.
@@ -3176,6 +3190,7 @@ private:
                 throw;
             }
             return;
+#ifndef PIRANHA_SINGLE_THREAD
         }
         // Number of buckets in retval.
         const bucket_size_type bucket_count = container.bucket_count();
@@ -3361,6 +3376,7 @@ private:
             retval._container().clear();
             throw;
         }
+#endif
     }
 };
 }

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -89,6 +89,7 @@ template <typename = void>
 class settings_ : private detail::base_settings<>
 {
 public:
+#ifndef PIRANHA_SINGLE_THREAD
     /// Get the number of threads available for use by piranha.
     /**
      * The initial value is set to the maximum between 1 and piranha::runtime_info::get_hardware_concurrency().
@@ -154,6 +155,7 @@ public:
     {
         return thread_pool::get_binding();
     }
+#endif
     /// Get the cache line size.
     /**
      * The initial value is set to the output of piranha::runtime_info::get_cache_line_size(). The value

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -89,23 +89,28 @@ template <typename = void>
 class settings_ : private detail::base_settings<>
 {
 public:
-#ifndef PIRANHA_SINGLE_THREAD
     /// Get the number of threads available for use by piranha.
     /**
      * The initial value is set to the maximum between 1 and piranha::runtime_info::get_hardware_concurrency().
      * This function is equivalent to piranha::thread_pool::size().
      *
-     * @return the number of threads that will be available for use by piranha.
+     * @return the number of threads that will be available for use by piranha. Note: if piranha is configured with
+     * PIRANHA_SINGLE_THREAD this function always returns 1.
      *
      * @throws unspecified any exception thrown by piranha::thread_pool::size().
      */
     static unsigned get_n_threads()
     {
+#ifndef PIRANHA_SINGLE_THREAD
         return thread_pool::size();
+#else
+      return 1u;
+#endif
     }
     /// Set the number of threads available for use by piranha.
     /**
-     * This function is equivalent to piranha::thread_pool::resize().
+     * This function is equivalent to piranha::thread_pool::resize(). Note: if piranha is configured with
+     * PIRANHA_SINGLE_THREAD this function does nothing.
      *
      * @param n the desired number of threads.
      *
@@ -113,24 +118,30 @@ public:
      */
     static void set_n_threads(unsigned n)
     {
+#ifndef PIRANHA_SINGLE_THREAD
         thread_pool::resize(n);
+#endif
     }
     /// Reset the number of threads available for use by piranha.
     /**
      * Will set the number of threads to the maximum between 1 and piranha::runtime_info::get_hardware_concurrency().
+     * Note: if piranha is configured with PIRANHA_SINGLE_THREAD this function does nothing.
      *
      * @throws unspecified any exception thrown by set_n_threads().
      */
     static void reset_n_threads()
     {
+#ifndef PIRANHA_SINGLE_THREAD
         const auto candidate = runtime_info::get_hardware_concurrency();
         set_n_threads((candidate > 0u) ? candidate : 1u);
+#endif
     }
     /// Set the thread binding policy.
     /**
      * This method is an alias for piranha::thread_pool::set_binding(). If \p flag is \p true, each
      * thread used by piranha will be bound to a different processor/core. If \p flag is \p false,
      * this method will unbind piranha's threads from any processor/core to which they might be bound.
+     * Note: if piranha is configured with PIRANHA_SINGLE_THREAD this function does nothing.
      *
      * By default piranha's threads are not bound to any specific processor/core.
      *
@@ -140,22 +151,28 @@ public:
      */
     static void set_thread_binding(bool flag)
     {
+#ifndef PIRANHA_SINGLE_THREAD
         thread_pool::set_binding(flag);
+#endif
     }
     /// Get the thread binding policy.
     /**
      * This method is an alias for piranha::thread_pool::get_binding(). It will return the flag set by
      * settings::set_thread_binding() (which is \p false by default on program startup).
      *
-     * @return the active thread binding policy.
+     * @return the active thread binding policy. Note: if piranha is configured with PIRANHA_SINGLE_THREAD this function
+     * always returns true.
      *
      * @throws unspecified any exception thrown by piranha::thread_pool::get_binding().
      */
     static bool get_thread_binding()
     {
+#ifndef PIRANHA_SINGLE_THREAD
         return thread_pool::get_binding();
-    }
+#else
+        return true;
 #endif
+    }
     /// Get the cache line size.
     /**
      * The initial value is set to the output of piranha::runtime_info::get_cache_line_size(). The value

--- a/src/thread_pool.hpp
+++ b/src/thread_pool.hpp
@@ -26,6 +26,12 @@ You should have received copies of the GNU General Public License and the
 GNU Lesser General Public License along with the Piranha library.  If not,
 see https://www.gnu.org/licenses/. */
 
+#include "config.hpp"
+
+#ifdef PIRANHA_SINGLE_THREAD
+#define PIRANHA_THREAD_POOL_HPP
+#endif
+
 #ifndef PIRANHA_THREAD_POOL_HPP
 #define PIRANHA_THREAD_POOL_HPP
 
@@ -50,7 +56,6 @@ see https://www.gnu.org/licenses/. */
 #include <utility>
 #include <vector>
 
-#include "config.hpp"
 #include "detail/atomic_lock_guard.hpp"
 #include "detail/mpfr.hpp"
 #include "exceptions.hpp"


### PR DESCRIPTION
I added the `PIRANHA_SINGLE_THREAD` option to CMake and I updated the documentation of some functions to note that the behaviour will deviate when configured with the `PIRANHA_SINGLE_THREAD` option.

I'm not sure how to update the `settings.hpp` file, I made the functions do noting or return a hardcoded value to still pass the tests but this may not be the best solution.

Closes #147 